### PR TITLE
Fix bug in is_column_rowid? if table schema entry is not present

### DIFF
--- a/lib/amalgalite/statement.rb
+++ b/lib/amalgalite/statement.rb
@@ -361,13 +361,16 @@ module Amalgalite
     # is the column indicated by the Column a 'rowid' column
     #
     def is_column_rowid?( table_name, column_name )
-      column_schema  = @db.schema.tables[table_name].columns[column_name]
-      if column_schema then
-        if column_schema.primary_key? and column_schema.declared_data_type and column_schema.declared_data_type.upcase == "INTEGER" then
-          return true
+      table_schema = @db.schema.tables[table_name]
+      if table_schema then
+        column_schema = table_schema.columns[column_name]
+        if column_schema then
+          if column_schema.primary_key? and column_schema.declared_data_type and column_schema.declared_data_type.upcase == "INTEGER" then
+            return true
+          end
+        else
+          return true if Statement.rowid_column_names.include?( column_name.upcase )
         end
-      else
-        return true if Statement.rowid_column_names.include?( column_name.upcase )
       end
       return false
     end


### PR DESCRIPTION
Maybe there is a deeper problem if the table schema entry is not present, but without this patch, amalgalite gives errors for some valid queries.  Run the following in the Sequel repository if you want an example:

```
SEQUEL_INTEGRATION_URL=amalgalite:/ spec spec/integration/schema_test.rb
```

With this patch, everything works fine.
