### PR TITLE
Handle debugging flags with debug-level in extconf.

### DIFF
--- a/ext/amalgalite/extconf.rb
+++ b/ext/amalgalite/extconf.rb
@@ -20,7 +20,7 @@ else
 end
 
 # remove the -g flags  if it exists
-%w[ -ggdb -g ].each do |debug|
+%w[ -ggdb\\d* -g\\d* ].each do |debug|
   $CFLAGS = $CFLAGS.gsub(/#{debug}/,'')
   RbConfig::MAKEFILE_CONFIG['debugflags'] = Config::MAKEFILE_CONFIG['debugflags'].gsub(/#{debug}/,'')   if Config::MAKEFILE_CONFIG['debugflags']
 end


### PR DESCRIPTION
This will handle the case where Ruby is built with extra debugging information (e.g., `-g3` or `-ggdb3`). If you don't include this, installation fails like so:

```
$ gem install amalgalite
Building native extensions.  This could take a while...
ERROR:  Error installing amalgalite:
ERROR: Failed to build gem native extension.

creating Makefile
make
compiling amalgalite3.c
clang: error: no such file or directory: '3'
make: *** [amalgalite3.o] Error 1
```

Thanks!
