### PR TITLE
Fixed typo in Readme.md. Makes instructions clearer to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is done using https://github.com/rake-compiler/rake-compiler-dock
 3. `gem install rake-compiler-dock`
 4. `rake-compiler-dock`
 5. `bundle`
-6 `rake cross native gem`
+6. `rake cross native gem`
 
 ## CREDITS
 


### PR DESCRIPTION
The Readme.md rendered a confusing instruction, caused by not having a "." in the 6th element of a list. I added the period to make it clearer. 

https://github.com/copiousfreetime/amalgalite/issues/30 is the issue. 