### PR TITLE
More robust filtering of debug flags in extconf.rb

### DIFF
--- a/ext/amalgalite/c/extconf.rb
+++ b/ext/amalgalite/c/extconf.rb
@@ -32,8 +32,8 @@ end
 
 # remove the -g flags  if it exists
 %w[ -ggdb\\d* -g\\d* ].each do |debug|
-  $CFLAGS = $CFLAGS.gsub(/#{debug}/,'')
-  RbConfig::MAKEFILE_CONFIG['debugflags'] = RbConfig::MAKEFILE_CONFIG['debugflags'].gsub(/#{debug}/,'')   if RbConfig::MAKEFILE_CONFIG['debugflags']
+  $CFLAGS = $CFLAGS.gsub(/\s#{debug}\b/,'')
+  RbConfig::MAKEFILE_CONFIG['debugflags'] = RbConfig::MAKEFILE_CONFIG['debugflags'].gsub(/\s#{debug}\b/,'')   if RbConfig::MAKEFILE_CONFIG['debugflags']
 end
 
 ignoreable_warnings = %w[ write-strings ]


### PR DESCRIPTION
The simple regexes had a problem with more complicated flags like
-grecord-gcc-switches, which they mangled into oblivion; a similar
issue would appear with any other switch with '-g' substring.

To avoid this problem, match only complete switches against the regexs.