### PR TITLE
Fix loading amalgalite on ruby 2.6.10

### DIFF
--- a/lib/amalgalite.rb
+++ b/lib/amalgalite.rb
@@ -21,7 +21,7 @@ end
 # this is the method recommended by rake-compiler
 begin
   # this will be for windows
-  require "amalgalite/#{RUBY_VERSION.sub(/\.\d$/,'')}/amalgalite"
+  require "amalgalite/#{RUBY_VERSION.sub(/\.\d+$/,'')}/amalgalite"
 rescue LoadError
   # everyone else.
   require 'amalgalite/amalgalite'


### PR DESCRIPTION
...and all others which will have patch number composed of two digits.

That problem has caused amalgalite to not load properly on ruby 2.6.10.

The issue is that:

```
"2.6.9".sub(/\.\d$/,'')
# => "2.6"
"2.6.10".sub(/\.\d$/,'')
# => "2.6.10"
```

And of course there is no "2.6.10" directory within the gem :)

After change from that PR:

```
"2.6.10".sub(/\.\d+$/,'')
# => "2.6"
"2.6.9".sub(/\.\d+$/,'')
# => "2.6"
```
